### PR TITLE
Add form label required class

### DIFF
--- a/dist/assets/css/styles.css
+++ b/dist/assets/css/styles.css
@@ -2127,6 +2127,10 @@ textarea.form__control {
       .checkbox .form__label,
       .radio .form__label {
         font-size: 1rem; } }
+  .form__label--required::after {
+    color: #c1272d;
+    content: '*';
+    padding-left: 5px; }
 
 .form__group--error .checkbox > input + span::before {
   border-color: #c1272d; }

--- a/src/assets/scss/6-components/forms/_forms.labels.scss
+++ b/src/assets/scss/6-components/forms/_forms.labels.scss
@@ -14,4 +14,12 @@
     .radio & {
         @include font-size-responsive($font-size-md-mobile, $font-size-md-desktop);
     }
+
+    &--required {
+        &::after {
+            color: $error-red;
+            content: '*';
+            padding-left: $space-xxs;
+        }
+    }
 }


### PR DESCRIPTION
This adds a red asterisk after a form label, useful for flagging required fields to the user.  I understand from Jane that we'll be doing this as standard going forward so useful to have it in the toolkit.