### PR TITLE
Fixed autocomplete styling / documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-point/pod-point-ui-toolkit",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A prototyping framework based on the pod point website, that can be used for getting a project off the ground quickly.",
   "author": "Matine Chabrier <matine.chabrier@pod-point.com>",
   "license": "MIT",

--- a/src/assets/scss/1-settings/_settings.typeahead.scss
+++ b/src/assets/scss/1-settings/_settings.typeahead.scss
@@ -16,3 +16,6 @@ $typeahead-group-dropdown-min-width: 340px;
 // Font sizes
 $typeahead-font-size-mobile: $font-size-md-mobile;
 $typeahead-font-size-desktop: $font-size-md-desktop;
+
+// Positioning
+$typeahead-z-index: 4;

--- a/src/assets/scss/1-settings/_settings.typeahead.scss
+++ b/src/assets/scss/1-settings/_settings.typeahead.scss
@@ -16,6 +16,3 @@ $typeahead-group-dropdown-min-width: 340px;
 // Font sizes
 $typeahead-font-size-mobile: $font-size-md-mobile;
 $typeahead-font-size-desktop: $font-size-md-desktop;
-
-// Positioning
-$typeahead-z-index: 4;

--- a/src/assets/scss/2-tools/_tools.typeahead.scss
+++ b/src/assets/scss/2-tools/_tools.typeahead.scss
@@ -8,7 +8,7 @@
     display: none;
     overflow: hidden;
     width: 100%;
-    z-index: 1;
+    z-index: $typeahead-z-index;
 
     &.is-active {
         @include margin($typeahead-option-margin 0 $typeahead-option-margin);

--- a/src/assets/scss/2-tools/_tools.typeahead.scss
+++ b/src/assets/scss/2-tools/_tools.typeahead.scss
@@ -4,11 +4,12 @@
 
 // Multiple list
 @mixin multiple-list {
+    @extend %z-index-4;
+
     border-color: $grey-keyline !important; // sass-lint:disable-line no-important
     display: none;
     overflow: hidden;
     width: 100%;
-    z-index: $typeahead-z-index;
 
     &.is-active {
         @include margin($typeahead-option-margin 0 $typeahead-option-margin);

--- a/src/assets/scss/7-trumps/_trumps.positions.scss
+++ b/src/assets/scss/7-trumps/_trumps.positions.scss
@@ -43,46 +43,90 @@
 }
 
 // z-indexes
-.z-index-1 {
+%z-index-1 {
     z-index: 1 !important;
 }
 
-.z-index-2 {
+%z-index-2 {
     z-index: 2 !important;
 }
 
-.z-index-3 {
+%z-index-3 {
     z-index: 3 !important;
 }
 
-.z-index-4 {
+%z-index-4 {
     z-index: 4 !important;
 }
 
-.z-index-5 {
+%z-index-5 {
     z-index: 5 !important;
 }
 
-.z-index-10 {
+%z-index-10 {
     z-index: 10 !important;
 }
 
-.z-index-20 {
+%z-index-20 {
     z-index: 20 !important;
 }
 
-.z-index-30 {
+%z-index-30 {
     z-index: 30 !important;
 }
 
-.z-index-40 {
+%z-index-40 {
     z-index: 40 !important;
 }
 
-.z-index-50 {
+%z-index-50 {
     z-index: 50 !important;
 }
 
-.z-index-99 {
+%z-index-99 {
     z-index: 99 !important;
+}
+
+.z-index-1 {
+    @extend %z-index-1;
+}
+
+.z-index-2 {
+    @extend %z-index-2;
+}
+
+.z-index-3 {
+    @extend %z-index-3;
+}
+
+.z-index-4 {
+    @extend %z-index-4;
+}
+
+.z-index-5 {
+    @extend %z-index-5;
+}
+
+.z-index-10 {
+    @extend %z-index-10;
+}
+
+.z-index-20 {
+    @extend %z-index-20;
+}
+
+.z-index-30 {
+    @extend %z-index-30;
+}
+
+.z-index-40 {
+    @extend %z-index-40;
+}
+
+.z-index-50 {
+    @extend %z-index-50;
+}
+
+.z-index-99 {
+    @extend %z-index-99;
 }

--- a/src/templates/pages/typeahead.hbs
+++ b/src/templates/pages/typeahead.hbs
@@ -314,11 +314,11 @@
                 </div>
             </section>
 
-            <section id=autocomplete-widget>
+            <section id=autocomplete">
                 <div class="content-block bg-light-grey">
                     <div class="container">
-                        <h3>Autocomplete Widget</h3>
-                        <p>You can use the input and list elements to create an autocomplete style widget, substituting the <code>.typeahead__list--dropdown</code> class for the <code>.typeahead__list--multiple</code> class and removing any unneeded markup.</p>
+                        <h3>Autocomplete</h3>
+                        <p>You can use a variation of the typeahead to create an autocomplete style component by taking the input element out of the typeahead list and removing the <code>.typeahead__input</code> class from it to prevent the overriding of the default form control styles.</p>
                     </div>
                 </div>
 
@@ -328,10 +328,12 @@
                             <label class="form__label">Autocomplete</label>
 
                             <div class="typeahead form__field">
-                                <div class="typeahead__list typeahead__list--multiple form__control is-active">
-                                    <input type="text" class="typeahead__input" placeholder="Search">
+                                <input type="text" class="form__control" placeholder="Search" />
 
-                                    <div class="typeahead__list typeahead__list--options"></div>
+                                <div class="typeahead__list typeahead__list--dropdown typeahead__list--options form__control">
+                                    <div class="typeahead__item typeahead__item--selectable" data-value="1">One</div>
+
+                                    <div class="typeahead__item typeahead__item--selectable" data-value="2">Two</div>
                                 </div>
                             </div>
                         </div>
@@ -340,14 +342,12 @@
                             <label class="form__label">Autocomplete</label>
 
                             <div class="typeahead form__field">
-                                <div class="typeahead__list typeahead__list--multiple form__control is-active">
-                                    <input type="text" class="typeahead__input" placeholder="Search">
+                                <input type="text" class="form__control" placeholder="Search" />
 
-                                    <div class="typeahead__list typeahead__list--options">
-                                        <div class="typeahead__item typeahead__item--selectable" data-value="1">One</div>
+                                <div class="typeahead__list typeahead__list--dropdown typeahead__list--options form__control is-active">
+                                    <div class="typeahead__item typeahead__item--selectable" data-value="1">One</div>
 
-                                        <div class="typeahead__item typeahead__item--selectable" data-value="2">Two</div>
-                                    </div>
+                                    <div class="typeahead__item typeahead__item--selectable" data-value="2">Two</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Using the suggested classes for an autocomplete style typeahead
resulted in the component being entirely relatively or absolutely
positioned, meaning the options took up space on the page and pushed
content below or the input element itself was lifted from the page
meaning the content below slotted underneath it.

To fix this:
* Taken the input element out of the typeahead list.
* Removed the typeahead input class to prevent the overriding of the
default form control styles on the input element.